### PR TITLE
Check keys (based on #2)

### DIFF
--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -668,10 +668,6 @@ class Container(ComplexView):
                 raise Exception("cannot have both a backing and elements to init List")
             return super().__new__(cls, backing=backing, hook=hook, **kwargs)
 
-        diff = set(kwargs.keys()).difference(set(cls.fields().keys()))
-        if len(diff) > 0:
-            raise AttributeError(f'The field names {diff} are not defined in {cls}')
-
         input_nodes = []
         for fkey, ftyp in cls.fields().items():
             fnode: Node
@@ -684,6 +680,9 @@ class Container(ComplexView):
             else:
                 fnode = ftyp.default_node()
             input_nodes.append(fnode)
+        # check if any keys are remaining to catch unrecognized keys
+        if len(kwargs) > 0:
+            raise AttributeError(f'The field names [{"".join(kwargs.keys())}] are not defined in {cls}')
         backing = subtree_fill_to_contents(input_nodes, cls.tree_depth())
         out = super().__new__(cls, backing=backing, hook=hook, **kwargs)
         return out

--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -684,7 +684,7 @@ class Container(ComplexView):
         if len(kwargs) > 0:
             raise AttributeError(f'The field names [{"".join(kwargs.keys())}] are not defined in {cls}')
         backing = subtree_fill_to_contents(input_nodes, cls.tree_depth())
-        out = super().__new__(cls, backing=backing, hook=hook, **kwargs)
+        out = super().__new__(cls, backing=backing, hook=hook)
         return out
 
     def __init_subclass__(cls, *args, **kwargs):

--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -668,8 +668,12 @@ class Container(ComplexView):
                 raise Exception("cannot have both a backing and elements to init List")
             return super().__new__(cls, backing=backing, hook=hook, **kwargs)
 
+        diff = set(kwargs.keys()).difference(set(cls.fields().keys()))
+        if len(diff) > 0:
+            raise AttributeError(f'The field names {diff} are not defined in {cls}')
+
         input_nodes = []
-        for i, (fkey, ftyp) in enumerate(cls.fields().items()):
+        for fkey, ftyp in cls.fields().items():
             fnode: Node
             if fkey in kwargs:
                 finput = kwargs.pop(fkey)

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -164,6 +164,12 @@ def test_container():
     except AttributeError:
         pass
 
+    try:
+        Foo(wrong_field_name=100)
+        assert False
+    except AttributeError:
+        pass
+
 
 def test_container_unpack():
     class Foo(Container):


### PR DESCRIPTION
- Clean up field key iteration, no need to enumerate
- Check remaining arguments to catch unexpected inputs
