### PR TITLE
More uint operators and r-op versions, for better typing in spec

### DIFF
--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -114,13 +114,13 @@ class uint(int, BasicView):
         raise OperationNotSupported(f"non-integer division '{other} / {self}' "
                                     f"is not valid for {self.__class__.type_repr()} right hand type")
 
-    def __pow__(self, other: int, modulo=None):
+    def __pow__(self: T, other: int, modulo=None) -> T:
         return self.__class__(super().__pow__(other, modulo))  # TODO: stricter argument checks?
 
-    def __rpow__(self, other, modulo=None):
+    def __rpow__(self: T, other, modulo=None) -> T:
         return self.__class__(super().__rpow__(other, modulo))  # TODO: see __pow__
 
-    def __lshift__(self, other: int) -> T:
+    def __lshift__(self: T, other: int) -> T:
         """Left bitshift clips bits at uint boundary"""
         mask = (1 << (self.type_byte_length() << 3)) - 1
         return self.__class__(super().__lshift__(int(other)) & mask)

--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -114,21 +114,23 @@ class uint(int, BasicView):
         raise OperationNotSupported(f"non-integer division '{other} / {self}' "
                                     f"is not valid for {self.__class__.type_repr()} right hand type")
 
-    def __pow__ (self, other: int, modulo = None):
+    def __pow__(self, other: int, modulo=None):
         return self.__class__(super().__pow__(other, modulo))  # TODO: stricter argument checks?
 
-    def __rpow__(self, other, modulo = None):
+    def __rpow__(self, other, modulo=None):
         return self.__class__(super().__rpow__(other, modulo))  # TODO: see __pow__
 
-    def __lshift__(self: T, other: int) -> T:
-        return self.__class__(super().__lshift__(other))
+    def __lshift__(self, other: int) -> T:
+        """Left bitshift clips bits at uint boundary"""
+        mask = (1 << (self.type_byte_length() << 3)) - 1
+        return self.__class__(super().__lshift__(int(other)) & mask)
 
     def __rlshift__(self: T, other: int) -> T:
         raise OperationNotSupported(f"{other} << {self} through __rlshift__ is not supported, "
                                     f"{other} must be a uint type with __lshift__")
 
     def __rshift__(self: T, other: int) -> T:
-        return self.__class__(super().__rshift__(other))
+        return self.__class__(super().__rshift__(int(other)))
 
     def __rrshift__(self: T, other: int) -> T:
         raise OperationNotSupported(f"{other} >> {self} through __rrshift__ is not supported, "
@@ -156,7 +158,8 @@ class uint(int, BasicView):
         raise OperationNotSupported(f"Cannot make uint type negative! If intentional, cast to signed int first.")
 
     def __invert__(self: T) -> T:
-        return self.__class__(super().__invert__())
+        mask = (1 << (self.type_byte_length() << 3)) - 1
+        return self.__xor__(mask)
 
     def __pos__(self: T) -> T:
         return self

--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -64,6 +64,9 @@ class boolean(int, BasicView):
         return "boolean"
 
 
+T = TypeVar('T', bound="uint")
+
+
 class uint(int, BasicView):
     def __new__(cls, value: int):
         if value < 0:
@@ -73,21 +76,95 @@ class uint(int, BasicView):
             raise ValueError(f"value out of bounds for {cls}")
         return super().__new__(cls, value)
 
-    def __add__(self, other):
+    def __add__(self: T, other: int) -> T:
         return self.__class__(super().__add__(self.__class__.coerce_view(other)))
 
-    def __sub__(self, other):
+    def __radd__(self: T, other: int) -> T:
+        return self.__add__(other)
+
+    def __sub__(self: T, other: int) -> T:
         return self.__class__(super().__sub__(self.__class__.coerce_view(other)))
 
-    def __mul__(self, other):
+    def __rsub__(self: T, other: int) -> T:
+        return self.__class__(self.__class__.coerce_view(other).__sub__(self))
+
+    def __mul__(self: T, other: int) -> T:
         return self.__class__(super().__mul__(self.__class__.coerce_view(other)))
 
-    def __floordiv__(self, other):  # Better known as "//"
+    def __rmul__(self: T, other: int) -> T:
+        return self.__mul__(other)
+
+    def __mod__(self: T, other: int) -> T:
+        return self.__class__(super().__mod__(self.__class__.coerce_view(other)))
+
+    def __rmod__(self: T, other: int) -> T:
+        return self.__class__(self.__class__.coerce_view(other).__mod__(self))
+
+    def __floordiv__(self: T, other: int) -> T:  # Better known as "//"
         return self.__class__(super().__floordiv__(self.__class__.coerce_view(other)))
 
-    def __truediv__(self, other):
+    def __rfloordiv__(self: T, other: int) -> T:
+        return self.__class__(self.__class__.coerce_view(other).__floordiv__(self))
+
+    def __truediv__(self: T, other: int) -> T:
         raise OperationNotSupported(f"non-integer division '{self} / {other}' "
-                                    f"is not valid for {self.__class__.type_repr()} type")
+                                    f"is not valid for {self.__class__.type_repr()} left hand type")
+
+    def __rtruediv__(self: T, other: int) -> T:
+        raise OperationNotSupported(f"non-integer division '{other} / {self}' "
+                                    f"is not valid for {self.__class__.type_repr()} right hand type")
+
+    def __pow__ (self, other: int, modulo = None):
+        return self.__class__(super().__pow__(other, modulo))  # TODO: stricter argument checks?
+
+    def __rpow__(self, other, modulo = None):
+        return self.__class__(super().__rpow__(other, modulo))  # TODO: see __pow__
+
+    def __lshift__(self: T, other: int) -> T:
+        return self.__class__(super().__lshift__(other))
+
+    def __rlshift__(self: T, other: int) -> T:
+        raise OperationNotSupported(f"{other} << {self} through __rlshift__ is not supported, "
+                                    f"{other} must be a uint type with __lshift__")
+
+    def __rshift__(self: T, other: int) -> T:
+        return self.__class__(super().__rshift__(other))
+
+    def __rrshift__(self: T, other: int) -> T:
+        raise OperationNotSupported(f"{other} >> {self} through __rrshift__ is not supported, "
+                                    f"{other} must be a uint type with __rshift__")
+
+    def __and__(self: T, other: int) -> T:
+        return self.__class__(super().__and__(self.__class__.coerce_view(other)))
+
+    def __rand__(self: T, other: int) -> T:
+        return self.__and__(other)
+
+    def __xor__(self: T, other: int) -> T:
+        return self.__class__(super().__xor__(self.__class__.coerce_view(other)))
+
+    def __rxor__(self: T, other: int) -> T:
+        return self.__xor__(other)
+
+    def __or__(self: T, other: int) -> T:
+        return self.__class__(super().__or__(self.__class__.coerce_view(other)))
+
+    def __ror__(self: T, other: int) -> T:
+        return self.__or__(other)
+
+    def __neg__(self):
+        raise OperationNotSupported(f"Cannot make uint type negative! If intentional, cast to signed int first.")
+
+    def __invert__(self: T) -> T:
+        return self.__class__(super().__invert__())
+
+    def __pos__(self: T) -> T:
+        return self
+
+    def __abs__(self: T) -> T:
+        return self
+
+    # __coerce__ is avoided to utilize explicit type hinting and special case the edge-cases for unsigned int safety
 
     @classmethod
     def coerce_view(cls: Type[V], v: Any) -> V:

--- a/remerkleable/test_arithmetic.py
+++ b/remerkleable/test_arithmetic.py
@@ -1,0 +1,205 @@
+from typing import Type, List, Callable
+
+import pytest
+
+from remerkleable.basic import uint, uint8, uint16, uint32, uint64, uint128, uint256, \
+    OperationNotSupported
+
+uint_types = [uint8, uint16, uint32, uint64, uint128, uint256]
+
+uint_valid_cases: List[Callable[[Type[uint]], int]] = [
+    lambda t: 0,
+    lambda t: 1,
+    lambda t: 3,
+    lambda t: 53,
+    lambda t: (1 << (8 * t.type_byte_length())) // 10,
+    lambda t: (1 << (8 * t.type_byte_length())) // 2,
+    lambda t: (1 << (8 * t.type_byte_length()))-1,
+]
+
+bi_operations = ['add', 'sub', 'floordiv', 'mul', 'mod', 'and', 'xor', 'or']
+reverse_bi_operations = [f'r{op}' for op in bi_operations]
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+@pytest.mark.parametrize("b", uint_valid_cases)
+@pytest.mark.parametrize("op", bi_operations + reverse_bi_operations)
+@pytest.mark.parametrize("b_unsigned", [True, False])
+def test_uint_arithmetic(typ, a, b, op, b_unsigned):
+    a_v = a(typ)
+    b_v = b(typ)
+    uint_a = typ(a_v)
+    uint_b = typ(b_v)
+    f = getattr(a_v, f'__{op}__')
+    regular_err = None
+    int_v = -1
+    try:
+        int_v = f(b_v)
+    except Exception as e:
+        regular_err = e
+
+    err = None
+    uint_v = None
+    try:
+        uint_f = getattr(uint_a, f'__{op}__')
+        uint_v = uint_f(uint_b if b_unsigned else b_v)
+    except Exception as e:
+        err = e
+
+    # E.g. divide by zero, modulo errors, etc. If it doesn't work for a python int, it shouldn't work for a uint as well
+    if err is not None and (err == regular_err or isinstance(err, type(regular_err))):
+        return
+
+    if int_v < 0 or int_v >= (1 << (8 * typ.type_byte_length())):
+        assert isinstance(err, ValueError)
+    else:
+        assert int(uint_v) == int_v
+        assert uint_v == typ(int_v)
+        assert isinstance(uint_v, typ)
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("v", [-256, -255, -3, -1])
+def test_uint_lower_bound(typ, v):
+    try:
+        typ(v)
+        raise Exception('expected value error')
+    except ValueError:
+        pass
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("vf", [
+    lambda t: (1 << (8 * t.type_byte_length())),
+    lambda t: (1 << (8 * t.type_byte_length())) + 1,
+    lambda t: (1 << (16 * t.type_byte_length())),
+])
+def test_uint_upper_bound(typ, vf):
+    try:
+        int_v = vf(typ)
+        typ(int_v)
+        raise Exception('expected value error')
+    except ValueError:
+        pass
+
+
+shift_cases: List[Callable[[Type[uint]], int]] = [
+    lambda t: 0,
+    lambda t: 1,
+    lambda t: 2,
+    lambda t: 8,
+    lambda t: (8 * t.type_byte_length()) // 10,
+    lambda t: (8 * t.type_byte_length()) // 2,
+    lambda t: (8 * t.type_byte_length()) - 1,
+    lambda t: (8 * t.type_byte_length()),
+    lambda t: (8 * t.type_byte_length()) + 1,
+    lambda t: (8 * t.type_byte_length()) * 2,
+]
+
+shift_operations = ['lshift', 'rshift']
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+@pytest.mark.parametrize("b", shift_cases)
+@pytest.mark.parametrize("op", shift_operations)
+@pytest.mark.parametrize("b_unsigned", [True, False])
+def test_uint_shifts(typ, a, b, op, b_unsigned):
+    a_v = a(typ)
+    b_v = b(typ)
+    uint_a = typ(a_v)
+    uint_b = typ(b_v)
+    f = getattr(a_v, f'__{op}__')
+    int_v = f(b_v)
+    uint_f = getattr(uint_a, f'__{op}__')
+    uint_v = uint_f(uint_b if b_unsigned else b_v)
+    mask = (1 << (typ.type_byte_length() << 3)) - 1
+    assert mask.to_bytes(length=typ.type_byte_length(), byteorder='little').hex() == 'ff' * typ.type_byte_length()
+    assert (int_v & mask) == int(uint_v)
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+@pytest.mark.parametrize("b_v", [0, 1, 2, 3, 5])
+@pytest.mark.parametrize("rev", [True, False])
+@pytest.mark.parametrize("b_unsigned", [True, False])
+def test_uint_pow(typ, a, b_v, rev, b_unsigned):
+    a_v = a(typ)
+    uint_a = typ(a_v)
+    uint_b = typ(b_v)
+
+    regular_err = None
+    int_v = -1
+    try:
+        int_v = a_v**b_v
+    except Exception as e:
+        regular_err = e
+
+    err = None
+    uint_v = None
+    try:
+        uint_v = uint_a**(uint_b if b_unsigned else b_v)
+    except Exception as e:
+        err = e
+
+    # If python ints can't handle it either, then it's ok
+    if err is not None and (err == regular_err or isinstance(err, type(regular_err))):
+        return
+
+    if int_v < 0 or int_v >= (1 << (8 * typ.type_byte_length())):
+        assert isinstance(err, ValueError)
+    else:
+        assert int(uint_v) == int_v
+        assert uint_v == typ(int_v)
+        assert isinstance(uint_v, typ)
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+def test_uint_negative(typ, a):
+    a_v = a(typ)
+    uint_a = typ(a_v)
+    try:
+        x = -uint_a
+        raise Exception(f"expected OperationNotSupported exception, but got result {x}")
+    except OperationNotSupported:
+        pass
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+@pytest.mark.parametrize("op", ['truediv', 'rtruediv', 'rlshift', 'rrshift'])
+def test_uint_bi_op_unsupported(typ, a, op):
+    a_v = a(typ)
+    uint_a = typ(a_v)
+    uint_f = getattr(uint_a, f'__{op}__')
+    try:
+        x = uint_f(42)
+        raise Exception(f"expected OperationNotSupported exception, but got result {x}")
+    except OperationNotSupported:
+        pass
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+def test_uint_identity(typ, a):
+    a_v = a(typ)
+    uint_a = typ(a_v)
+    assert a_v == abs(uint_a)
+    assert a_v == +uint_a
+
+
+@pytest.mark.parametrize("typ", uint_types)
+@pytest.mark.parametrize("a", uint_valid_cases)
+def test_uint_invert(typ, a):
+    a_v = a(typ)
+    uint_a = typ(a_v)
+    inverted_a = ~uint_a
+    mask = (1 << (typ.type_byte_length() << 3)) - 1
+    assert uint_a | inverted_a == mask
+    assert inverted_a != uint_a
+    bitlen = uint_a.type_byte_length() * 8
+    bits = [(1 << i) & uint_a != 0 for i in range(bitlen)]
+    inverted_bits = [(1 << i) & inverted_a != 0 for i in range(bitlen)]
+    assert all(bits[i] != inverted_bits[i] for i in range(bitlen))


### PR DESCRIPTION
As suggested by @ericsson49: use r-op methods like `__radd__` to preserve remerkleable types when used with regular integers.

And extend the current operation set to cover remaining things, also based on further discussion with @ericsson49

More type-var hints have been added as well, to make it explicit that an `int` is acceptable as `other` operand. A runtime error will be raised if it cannot be coerced. I'm not sure if `other` should just be `T` instead, as I would like `int` literals to be resolved automatically, but subclasses of other sizes should not. Subtracting a `uint64` from a `uint8` for example should not be valid. Something to test and tweak before merge.

This is a draft PR, I plan to add some tests next week before introducing the changes.