### PR TITLE
MyPy checks

### DIFF
--- a/.github/workflows/ci_py.yaml
+++ b/.github/workflows/ci_py.yaml
@@ -24,13 +24,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-      - name: Lint with flake8
+      - name: Lint with flake8 and mypy
         run: |
           pip install .[linting]
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=15 --max-line-length=127 --statistics
+          # Run mypy on main package
+          mypy remerkleable
       - name: Test with pytest
         run: |
           pip install .[testing]

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install:
 
 lint:
 	cd remerkleable && flake8 . --count --exit-zero --max-complexity=15 --max-line-length=127 --statistics
+	mypy remerkleable
 
 clean:
 	rm -rf build dist .pytest_cache *.egg-info

--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -10,6 +10,9 @@ class OperationNotSupported(Exception):
     pass
 
 
+BoolV = TypeVar('BoolV', bound="boolean")
+
+
 class boolean(int, BasicView):
 
     def encode_bytes(self) -> bytes:
@@ -18,7 +21,7 @@ class boolean(int, BasicView):
     def __new__(cls, value: int):  # int value, but can be any subclass of int (bool, Bit, Bool, etc...)
         if value < 0 or value > 1:
             raise ValueError(f"value {value} out of bounds for bit")
-        return super().__new__(cls, value)
+        return super().__new__(cls, value)  # type: ignore
 
     def __add__(self, other):
         raise OperationNotSupported(f"cannot add bool ({self} + {other})")
@@ -39,7 +42,7 @@ class boolean(int, BasicView):
         return self > 0
 
     @classmethod
-    def coerce_view(cls: Type[V], v: Any) -> V:
+    def coerce_view(cls: Type[BoolV], v: Any) -> BoolV:
         return cls(v)
 
     @classmethod
@@ -47,11 +50,11 @@ class boolean(int, BasicView):
         return 1
 
     @classmethod
-    def decode_bytes(cls: Type[V], bytez: bytes) -> V:
+    def decode_bytes(cls: Type[BoolV], bytez: bytes) -> BoolV:
         return cls(bytez != b"\x00")
 
     @classmethod
-    def from_obj(cls: Type[V], obj: ObjType) -> V:
+    def from_obj(cls: Type[BoolV], obj: ObjType) -> BoolV:
         if not isinstance(obj, bool):
             raise ObjParseException(f"obj '{obj}' is not a bool")
         return cls(obj)
@@ -74,7 +77,7 @@ class uint(int, BasicView):
         byte_len = cls.type_byte_length()
         if value.bit_length() > (byte_len << 3):
             raise ValueError(f"value out of bounds for {cls}")
-        return super().__new__(cls, value)
+        return super().__new__(cls, value)  # type: ignore
 
     def __add__(self: T, other: int) -> T:
         return self.__class__(super().__add__(self.__class__.coerce_view(other)))
@@ -108,11 +111,11 @@ class uint(int, BasicView):
     def __rfloordiv__(self: T, other: int) -> T:
         return self.__class__(self.__class__.coerce_view(other).__floordiv__(self))
 
-    def __truediv__(self: T, other: int) -> T:
+    def __truediv__(self, other):
         raise OperationNotSupported(f"non-integer division '{self} / {other}' "
                                     f"is not valid for {self.__class__.type_repr()} left hand type")
 
-    def __rtruediv__(self: T, other: int) -> T:
+    def __rtruediv__(self, other):
         raise OperationNotSupported(f"non-integer division '{other} / {self}' "
                                     f"is not valid for {self.__class__.type_repr()} right hand type")
 
@@ -172,7 +175,7 @@ class uint(int, BasicView):
     # __coerce__ is avoided to utilize explicit type hinting and special case the edge-cases for unsigned int safety
 
     @classmethod
-    def coerce_view(cls: Type[V], v: Any) -> V:
+    def coerce_view(cls: Type[T], v: Any) -> T:
         if isinstance(v, uint) and cls.type_byte_length() != v.__class__.type_byte_length():
             raise ValueError("value must have equal byte length to coerce it")
         if isinstance(v, bytes):
@@ -180,14 +183,14 @@ class uint(int, BasicView):
         return cls(v)
 
     @classmethod
-    def decode_bytes(cls: Type[V], bytez: bytes) -> V:
+    def decode_bytes(cls: Type[T], bytez: bytes) -> T:
         return cls(int.from_bytes(bytez, byteorder='little'))
 
     def encode_bytes(self) -> bytes:
         return self.to_bytes(length=self.__class__.type_byte_length(), byteorder='little')
 
     @classmethod
-    def from_obj(cls: Type[V], obj: ObjType) -> V:
+    def from_obj(cls: Type[T], obj: ObjType) -> T:
         if not isinstance(obj, (int, str)):
             raise ObjParseException(f"obj '{obj}' is not an int or str")
         if isinstance(obj, str):

--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -68,6 +68,7 @@ class boolean(int, BasicView):
 
 
 T = TypeVar('T', bound="uint")
+W = TypeVar('W', bound=int)
 
 
 class uint(int, BasicView):
@@ -130,20 +131,20 @@ class uint(int, BasicView):
         mask = (1 << (self.type_byte_length() << 3)) - 1
         return self.__class__(super().__lshift__(int(other)) & mask)
 
-    def __rlshift__(self: T, other: "uint") -> T:
+    def __rlshift__(self, other: W) -> W:
         if not isinstance(other, uint):
             raise ValueError(f"{other} << {self} through __rlshift__ is not supported, "
                              f"left operand {other} must be a uint type with __lshift__")
-        return other.__lshift__(self)
+        return other.__lshift__(self)  # type: ignore
 
     def __rshift__(self: T, other: int) -> T:
         return self.__class__(super().__rshift__(int(other)))
 
-    def __rrshift__(self: T, other: "uint") -> T:
+    def __rrshift__(self, other: W) -> W:
         if not isinstance(other, uint):
             raise ValueError(f"{other} >> {self} through __rrshift__ is not supported, "
                              f"left operand {other} must be a uint type with __rshift__")
-        return other.__rshift__(self)
+        return other.__rshift__(self)  # type: ignore
 
     def __and__(self: T, other: int) -> T:
         return self.__class__(super().__and__(self.__class__.coerce_view(other)))

--- a/remerkleable/bitfields.py
+++ b/remerkleable/bitfields.py
@@ -104,7 +104,7 @@ class BitsView(BackedView, ColSequence):
             if obj.startswith('0x'):
                 return cls.decode_bytes(bytes.fromhex(obj[2:]))
             obj = [c == '1' for c in obj]
-        return cls(obj)
+        return cls(obj)  # type: ignore
 
     def to_obj(self) -> ObjType:
         return '0x' + self.encode_bytes().hex()
@@ -291,7 +291,7 @@ class Bitlist(BitsView):
             raise Exception(f"bitlist too long: {bitlen}, delimiting bit is over limit ({cls.limit()})")
         contents = subtree_fill_to_contents(chunks, cls.contents_depth())
         backing = PairNode(contents, uint256(bitlen).get_backing())
-        return cast(Bitlist, cls.view_from_backing(backing))
+        return cls.view_from_backing(backing)
 
     def serialize(self, stream: BinaryIO) -> int:
         backing = self.get_backing()
@@ -423,7 +423,7 @@ class Bitvector(BitsView, FixedByteLengthViewHelper):
         last_chunk = last_chunk_part + (b"\x00" * (32 - len(last_chunk_part)))
         chunks.append(RootNode(Root(last_chunk)))
         backing = subtree_fill_to_contents(chunks, cls.tree_depth())
-        return cast(Bitvector, cls.view_from_backing(backing))
+        return cls.view_from_backing(backing)
 
     def serialize(self, stream: BinaryIO) -> int:
         backing = self.get_backing()

--- a/remerkleable/history.py
+++ b/remerkleable/history.py
@@ -1,8 +1,8 @@
 from remerkleable.tree import Gindex, Node, get_anchor_gindex, ROOT_GINDEX
-from typing import List as Iterable, Tuple, TypeVar
+from typing import List, Tuple, TypeVar
 
 K = TypeVar('K')
-History = Iterable[Tuple[K, Node]]
+History = List[Tuple[K, Node]]
 
 
 def get_target_history(history: History, target: Gindex) -> History:
@@ -23,7 +23,7 @@ def get_target_history(history: History, target: Gindex) -> History:
     # Don't go deeper than the anchor. In this case we just return the (duplicate reduced) history.
     is_anchor = (anchor == ROOT_GINDEX)
 
-    out = []
+    out: History = []
     last = None
 
     for key, node in history:

--- a/remerkleable/subtree.py
+++ b/remerkleable/subtree.py
@@ -1,9 +1,9 @@
 from typing import Type, cast
-from remerkleable.core import TypeDef, View, BackedView, BasicTypeDef, BasicView
+from remerkleable.core import View, BackedView, BasicView
 from remerkleable.tree import Link, to_gindex
 
 
-class SubtreeView(BackedView, TypeDef):
+class SubtreeView(BackedView):
     @classmethod
     def is_packed(cls) -> bool:
         raise NotImplementedError
@@ -35,16 +35,13 @@ class SubtreeView(BackedView, TypeDef):
             v = elem_type.coerce_view(v)
         if self.is_packed():
             # basic types are more complicated: we operate on a subsection of a bottom chunk
-            if isinstance(elem_type, BasicTypeDef):
-                if not isinstance(v, BasicView):
-                    raise Exception("input element is not a basic view")
-                basic_v: BasicView = v
-                elems_per_chunk = 32 // elem_type.type_byte_length()
+            if isinstance(v, BasicView):
+                elems_per_chunk = 32 // v.type_byte_length()
                 chunk_i = i // elems_per_chunk
                 target = to_gindex(chunk_i, self.tree_depth())
                 chunk_setter_link: Link = self.get_backing().setter(target)
                 chunk = self.get_backing().getter(target)
-                new_chunk = basic_v.backing_from_base(chunk, i % elems_per_chunk)
+                new_chunk = v.backing_from_base(chunk, i % elems_per_chunk)
                 self.set_backing(chunk_setter_link(new_chunk))
             else:
                 raise Exception("cannot pack subtree elements that are not basic types")

--- a/remerkleable/test_arithmetic.py
+++ b/remerkleable/test_arithmetic.py
@@ -1,6 +1,6 @@
 from typing import Type, List, Callable
 
-import pytest
+import pytest  # type: ignore
 
 from remerkleable.basic import uint, uint8, uint16, uint32, uint64, uint128, uint256, \
     OperationNotSupported

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 # flake8:noqa E501  Ignore long lines, some test cases are just inherently long
 
 from typing import Iterable, Type
@@ -6,7 +8,7 @@ from remerkleable.complex import Container, Vector, List
 from remerkleable.basic import boolean, bit, byte, uint8, uint16, uint32, uint64, uint128, uint256
 from remerkleable.bitfields import Bitvector, Bitlist
 from remerkleable.byte_arrays import ByteVector, ByteList
-from remerkleable.core import TypeDef, View, ObjType
+from remerkleable.core import View, ObjType
 from hashlib import sha256
 
 import json
@@ -360,11 +362,6 @@ def test_type_bounds(name: str, typ: Type[View], value: View, serialized: str, r
 @pytest.mark.parametrize("name, typ, value, serialized, root, obj", test_data)
 def test_value_byte_length(name: str, typ: Type[View], value: View, serialized: str, root: str, obj: ObjType):
     assert value.value_byte_length() == len(bytes.fromhex(serialized))
-
-
-@pytest.mark.parametrize("name, typ, value, serialized, root, obj", test_data)
-def test_typedef(name: str, typ: Type[View], value: View, serialized: str, root: str, obj: ObjType):
-    assert issubclass(typ, TypeDef)
 
 
 @pytest.mark.parametrize("name, typ, value, serialized, root, obj", test_data)

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -1,15 +1,15 @@
 # flake8:noqa F401  Ignore unused imports. Tests are a work in progress.
-import pytest
+
+import pytest  # type: ignore
 
 from random import Random
 
-from remerkleable.core import View, TypeDef, BasicView
 from remerkleable.complex import Container, Vector, List
 from remerkleable.basic import boolean, bit, uint, byte, uint8, uint16, uint32, uint64, uint128, uint256,\
     OperationNotSupported
 from remerkleable.bitfields import Bitvector, Bitlist
 from remerkleable.byte_arrays import ByteVector, Bytes1, Bytes4, Bytes8, Bytes32, Bytes48, Bytes96
-from remerkleable.core import BasicView, View, TypeDef
+from remerkleable.core import BasicView, View
 from remerkleable.tree import get_depth
 
 
@@ -26,14 +26,11 @@ def test_subclasses():
         assert issubclass(u, int)
         assert issubclass(u, View)
         assert issubclass(u, BasicView)
-        assert isinstance(u, TypeDef)
     assert issubclass(boolean, BasicView)
     assert issubclass(boolean, View)
-    assert isinstance(boolean, TypeDef)
 
     for c in [Container, List, Vector, Bytes32]:
         assert issubclass(c, View)
-        assert isinstance(c, TypeDef)
 
 
 def test_basic_instances():
@@ -186,7 +183,6 @@ def test_list():
     typ = List[uint64, 128]
     assert issubclass(typ, List)
     assert issubclass(typ, View)
-    assert isinstance(typ, TypeDef)
 
     assert not typ.is_fixed_byte_length()
 
@@ -254,12 +250,13 @@ def test_bytesn_subclass():
     class Root(Bytes32):
         pass
 
-    assert isinstance(Root(b'\xab' * 32), Bytes32)
-    assert not isinstance(Root(b'\xab' * 32), Bytes48)
-    assert issubclass(Root(b'\xab' * 32).__class__, Bytes32)
-    assert issubclass(Root, Bytes32)
+    # mypy does not like instance checks with parametrized generics, but they work, python can do everything
+    assert isinstance(Root(b'\xab' * 32), Bytes32)  # type: ignore
+    assert not isinstance(Root(b'\xab' * 32), Bytes48)  # type: ignore
+    assert issubclass(Root(b'\xab' * 32).__class__, Bytes32)  # type: ignore
+    assert issubclass(Root, Bytes32)  # type: ignore
 
-    assert not issubclass(Bytes48, Bytes32)
+    assert not issubclass(Bytes48, Bytes32)  # type: ignore
 
     assert len(Bytes32() + Bytes48()) == 80
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     tests_require=[],
     extras_require={
         "testing": ["pytest"],
-        "linting": ["flake8"],
+        "linting": ["flake8", "mypy"],
         "docs": ["sphinx", "sphinx-autodoc-typehints", "pallets_sphinx_themes", "sphinx_issues"]
     },
     install_requires=[],


### PR DESCRIPTION
Support Mypy:
- Use more specific type-vars for various class methods
- No more separate TypeDef superclass. It's just a collection of classmethods anyway, not a metaclass. Unified with View class now.
- Same for BasicTypeDef/BasicView, with adjustments in basic-type checking. Use `isinstance(v, BasicView)` or `issubclass(t, BasicView)` now.
- Fix a few minor type annotation issues (e.g. bounded typevar return without matching typevar)
- Added mypy to `make lint` (run in venv)


Catches:
- Parametrized generics are very possible in python, but MyPy doesn't like them. Ignored the few usages for now.
- `_ProtocolMeta` is still used, since we need to override `/` on the class level, which is only possible though overloading via a metaclass (classmethod decorator doesn't seem to work on operator overload). And `Protocol` cannot be used otherwise due to metaclass conflicts (limitation of typing implemention).
- Often when a view is created like `cls(......)`, mypy doesn't understand that subclasses can catch the remaining arguments, and the superclass is Protocol and/or a BackedView, inherited by regular views. Ignored these cases for now.

