### PR TITLE
uint r-l/r-shifts

### DIFF
--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -127,16 +127,20 @@ class uint(int, BasicView):
         mask = (1 << (self.type_byte_length() << 3)) - 1
         return self.__class__(super().__lshift__(int(other)) & mask)
 
-    def __rlshift__(self: T, other: int) -> T:
-        raise OperationNotSupported(f"{other} << {self} through __rlshift__ is not supported, "
-                                    f"{other} must be a uint type with __lshift__")
+    def __rlshift__(self: T, other: "uint") -> T:
+        if not isinstance(other, uint):
+            raise ValueError(f"{other} << {self} through __rlshift__ is not supported, "
+                             f"left operand {other} must be a uint type with __lshift__")
+        return other.__lshift__(self)
 
     def __rshift__(self: T, other: int) -> T:
         return self.__class__(super().__rshift__(int(other)))
 
-    def __rrshift__(self: T, other: int) -> T:
-        raise OperationNotSupported(f"{other} >> {self} through __rrshift__ is not supported, "
-                                    f"{other} must be a uint type with __rshift__")
+    def __rrshift__(self: T, other: "uint") -> T:
+        if not isinstance(other, uint):
+            raise ValueError(f"{other} >> {self} through __rrshift__ is not supported, "
+                             f"left operand {other} must be a uint type with __rshift__")
+        return other.__rshift__(self)
 
     def __and__(self: T, other: int) -> T:
         return self.__class__(super().__and__(self.__class__.coerce_view(other)))


### PR DESCRIPTION
This PR:
- Allows:
  - `uintN(a) << uintM(b)`  (e.g. `byte(123) >> uint64(3)` as used in the eth2 spec)
  - `uintN(a) << int(b)` (right operand may be a literal, its size is not really important for the result, only its value is)
  - `uintN(a) >> uintM(b)`
  - `uintN(a) >> int(b)`
-  Since the size of the left operand changes the result, it raises a ValueError on:
  - `int(a) << uintN(b)`
  - `int(a) >> uintN(b)`
- Updates tests to reflect this

Thanks @hwwhww for the bug report.

