### PR TITLE
SSZ object-oriented-programming

### DIFF
--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -463,9 +463,9 @@ def test_container_inheritance():
     assert Duplicates.fields() == {'a': uint64, 'b': uint32, 'c': uint8, 'aa': uint64, 'm': uint8}
     assert Duplicates._field_indices == {'a': 0, 'b': 1, 'c': 2, 'aa': 3, 'm': 4}
 
-    # overriding
+    # overriding with different type
     class FancyChocoBar(ChocoBar):
-        aa: uint128
+        aa: uint128  # type: ignore
 
     assert FancyChocoBar.fields() == {'a': uint64, 'b': uint32, 'c': uint8, 'aa': uint128}
     assert FancyChocoBar._field_indices == {'a': 0, 'b': 1, 'c': 2, 'aa': 3}
@@ -476,7 +476,7 @@ def test_container_inheritance():
     # overriding and extending
     class ExtendedFancyChocoBar(ChocoBar):
         more: uint16
-        aa: uint128
+        aa: uint128  # type: ignore
 
     # overriden field must stay in place
     assert ExtendedFancyChocoBar.fields() == {'a': uint64, 'b': uint32, 'c': uint8, 'aa': uint128, 'more': uint16}


### PR DESCRIPTION
All of this functionality is OPTIONAL use and does NOT change the SSZ spec in any way.

I much prefer composition and embedding for things, but that may not be as powerful, nor does it fit Python well.
So to avoid code duplication, and make things truly independent (no need for phases), SSZ containers can now support python-like class inheritance.

The test case is full of examples of how to use it. TLDR: inherit multiple base classes, or extend just one.
Fields will stay in the location they were first seen at, and can change type (not recommended, mypy will complain too)

Other languages may like to implement something similar, or just redefine new types with the same effective list of fields.