### PR TITLE
Bitfield typing fix

### DIFF
--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -165,7 +165,7 @@ class uint(int, BasicView):
         return self.__or__(other)
 
     def __neg__(self):
-        raise OperationNotSupported(f"Cannot make uint type negative! If intentional, cast to signed int first.")
+        raise OperationNotSupported("Cannot make uint type negative! If intentional, cast to signed int first.")
 
     def __invert__(self: T) -> T:
         mask = (1 << (self.type_byte_length() << 3)) - 1

--- a/remerkleable/bitfields.py
+++ b/remerkleable/bitfields.py
@@ -37,6 +37,7 @@ class BitsView(BackedView, ColSequence):
 
     def get(self, i: int) -> boolean:
         ll = self.length()
+        i = int(i)  # downcast, access type can have stricter bit operation typing than necessary.
         if i >= ll:
             raise NavigationError(f"cannot get bit {i} in bits of length {ll}")
         chunk_i = i >> 8
@@ -46,6 +47,7 @@ class BitsView(BackedView, ColSequence):
 
     def set(self, i: int, v: boolean) -> None:
         ll = self.length()
+        i = int(i)  # downcast, access type can have stricter bit operation typing than necessary.
         if i >= ll:
             raise NavigationError(f"cannot set bit {i} in bits of length {ll}")
         chunk_i = i >> 8

--- a/remerkleable/bitfields.py
+++ b/remerkleable/bitfields.py
@@ -37,7 +37,7 @@ class BitsView(BackedView, ColSequence):
 
     def get(self, i: int) -> boolean:
         ll = self.length()
-        i = int(i)  # downcast, access type can have stricter bit operation typing than necessary.
+        i = int(i)  # coerce to int, access type can have stricter bit operation typing than necessary.
         if i >= ll:
             raise NavigationError(f"cannot get bit {i} in bits of length {ll}")
         chunk_i = i >> 8
@@ -47,7 +47,7 @@ class BitsView(BackedView, ColSequence):
 
     def set(self, i: int, v: boolean) -> None:
         ll = self.length()
-        i = int(i)  # downcast, access type can have stricter bit operation typing than necessary.
+        i = int(i)  # coerce to int, access type can have stricter bit operation typing than necessary.
         if i >= ll:
             raise NavigationError(f"cannot set bit {i} in bits of length {ll}")
         chunk_i = i >> 8

--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -882,7 +882,7 @@ class Container(_ContainerBase):
                     fixed_size += OFFSET_BYTE_LENGTH
             if len(dyn_fields) > 0:
                 if dyn_fields[0].offset < fixed_size:
-                    raise Exception(f"first offset is smaller than expected fixed size")
+                    raise Exception("first offset is smaller than expected fixed size")
                 for i, (fkey, ftyp, foffset) in enumerate(dyn_fields):
                     next_offset = dyn_fields[i + 1].offset if i + 1 < len(dyn_fields) else scope
                     if foffset > next_offset:

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -401,6 +401,23 @@ def test_bitlist_iter():
                 assert bool(bit) == bools[i]
 
 
+def test_bitlist_access():
+    bf = Bitlist[200](i % 2 == 1 for i in range(200))
+    assert bf[int(123)]
+    assert bf[uint64(123)]
+    assert not bf[uint64(124)]
+    assert not bf[uint8(42)]
+    assert bf[uint8(43)]
+
+    assert bf[len(bf)-1]
+    bf.pop()
+    assert not bf[len(bf)-1]
+    bf.pop()
+    assert bf[len(bf)-1]
+    bf.append(True)
+    assert bf[len(bf)-1]
+
+
 def test_container_inheritance():
     class Foo(Container):
         a: uint64


### PR DESCRIPTION
CC @ralexstokes

Fixes accessor type conversion constraints by internally downcasting the input to an `int` when doing lookups.

Also includes minor fixes to make linter happy.

See https://github.com/ethereum/eth2.0-specs/pull/2311#discussion_r608248641

