### PR TITLE
Make `Union[<non-None type>]` valid

### DIFF
--- a/.github/workflows/ci_py.yaml
+++ b/.github/workflows/ci_py.yaml
@@ -1,6 +1,6 @@
 name: Remerkleable Python CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -176,6 +176,8 @@ test_data = [
        h(h(h(chunk("03"), chunk("")), zero_hashes[1]), chunk(""))),
      ("0x01" + ("00" * 95), "0x02" + ("00" * 95), "0x03" + ("00" * 95)),
      ),
+    ("single_type_union", Union[uint16], Union[uint16](selector=0, value=uint16(0xaabb)),
+     "00bbaa", h(chunk("bbaa"), chunk("")), {'selector': 0, 'value': 0xaabb}),
     ("simple_union", Union[uint16, uint32], Union[uint16, uint32](selector=0, value=uint16(0xaabb)),
      "00bbaa", h(chunk("bbaa"), chunk("")), {'selector': 0, 'value': 0xaabb}),
     ("union with none", Union[None, uint16, uint32], Union[None, uint16, uint32](selector=0, value=None),

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -537,6 +537,9 @@ def test_union():
     assert foo2.selector() == 2
     assert foo2.selected_type() == uint16
 
+    # Only one non-none option
+    foo = Union[uint32]()
+
     # No union with just a None option
     try:
         bar = Union[None]

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -539,6 +539,19 @@ def test_union():
 
     # Only one non-none option
     foo = Union[uint32]()
+    assert foo.options() == [uint32]
+
+    # Max options (128)
+    max_opts = [uint32] + ([uint16] * 126) + [uint8]
+    bar = Union.__class_getitem__(tuple(max_opts))
+    assert bar.options() == list(max_opts)
+
+    # No union with too many options
+    try:
+        bar = Union.__class_getitem__((uint16,) * 129)
+        assert False
+    except TypeError:
+        pass
 
     # No union with just a None option
     try:

--- a/remerkleable/union.py
+++ b/remerkleable/union.py
@@ -1,7 +1,7 @@
 from typing import cast, Sequence, Any, BinaryIO, Optional, TypeVar, Type, Union as PyUnion
 from textwrap import indent
 import io
-from remerkleable.core import View, BackedView, ViewHook, ObjType
+from remerkleable.core import View, BackedView, ViewHook, ObjType, ViewMeta
 from remerkleable.basic import uint256
 from remerkleable.tree import Node, zero_node, Gindex, PairNode
 from remerkleable.tree import LEFT_GINDEX, RIGHT_GINDEX
@@ -63,7 +63,10 @@ class Union(BackedView):
         if len(union_options) > 128:
             raise TypeError(f"expected no more than 128 type options, but got {len(union_options)}")
 
-        union_options_list: Sequence[PyUnion[Type[View], None]] = list(*union_options)
+        if isinstance(*union_options, ViewMeta):
+            union_options_list: Sequence[PyUnion[Type[View], None]] = list(union_options)
+        else:
+            union_options_list: Sequence[PyUnion[Type[View], None]] = list(*union_options)
 
         for (i, x) in enumerate(union_options_list):
             if x is None and i == 0:

--- a/remerkleable/union.py
+++ b/remerkleable/union.py
@@ -1,7 +1,7 @@
 from typing import cast, Sequence, Any, BinaryIO, Optional, TypeVar, Type, Union as PyUnion
 from textwrap import indent
 import io
-from remerkleable.core import View, BackedView, ViewHook, ObjType, ViewMeta
+from remerkleable.core import View, BackedView, ViewHook, ObjType
 from remerkleable.basic import uint256
 from remerkleable.tree import Node, zero_node, Gindex, PairNode
 from remerkleable.tree import LEFT_GINDEX, RIGHT_GINDEX
@@ -57,16 +57,15 @@ class Union(BackedView):
             right=uint256(selector).get_backing())
         return super().__new__(cls, backing=backing, hook=hook, **kwargs)
 
-    def __class_getitem__(cls, *union_options) -> Type["Union"]:
+    def __class_getitem__(cls, union_options) -> Type["Union"]:
+        if not isinstance(union_options, tuple):  # single-element arguments are not passed as single-element tuple.
+            union_options = (union_options,)
         if len(union_options) < 1:
             raise TypeError("expected at least one Union type option")
         if len(union_options) > 128:
             raise TypeError(f"expected no more than 128 type options, but got {len(union_options)}")
 
-        if isinstance(*union_options, ViewMeta):
-            union_options_list: Sequence[PyUnion[Type[View], None]] = list(union_options)
-        else:
-            union_options_list: Sequence[PyUnion[Type[View], None]] = list(*union_options)
+        union_options_list: Sequence[PyUnion[Type[View], None]] = list(union_options)
 
         for (i, x) in enumerate(union_options_list):
             if x is None and i == 0:


### PR DESCRIPTION
### Issue
Pointed out by @JustinDrake in https://github.com/ethereum/eth2.0-specs/pull/2472, we saw errors around `Union[OpaqueTransaction]`.
```sh
  Transaction = Union[OpaqueTransaction]
../../../venv/lib/python3.8/site-packages/remerkleable/union.py:66: in __class_getitem__
    union_options_list: Sequence[PyUnion[Type[View], None]] = list(*union_options)
E   TypeError: 'ViewMeta' object is not iterable
```

IIUC from [the SSZ spec](https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/simple-serialize.md#union), `Union[<non-None type>]` should be valid. @protolambda  what do you think?


### How to fix it

It seems the issue was that when it executes `union_options_list: Sequence[PyUnion[Type[View], None]] = list(*union_options)`, the single type `ViewMeta` could not be unpacked and packed as we expected. I added a check here to deal with this case.
