### PR TITLE
fix tree filling for default `Vector` constructor

### DIFF
--- a/remerkleable/tree.py
+++ b/remerkleable/tree.py
@@ -231,7 +231,7 @@ def subtree_fill_to_length(bottom: Node, depth: int, length: int) -> Node:
         anchor = 1 << depth
         pivot = anchor >> 1
         if length <= pivot:
-            return PairNode(subtree_fill_to_length(bottom, depth - 1, length), zero_node(depth-1))
+            return PairNode(subtree_fill_to_length(bottom, depth - 1, length), zero_node(depth - 1))
         else:
             return PairNode(
                 subtree_fill_to_depth(bottom, depth-1),

--- a/remerkleable/tree.py
+++ b/remerkleable/tree.py
@@ -231,7 +231,7 @@ def subtree_fill_to_length(bottom: Node, depth: int, length: int) -> Node:
         anchor = 1 << depth
         pivot = anchor >> 1
         if length <= pivot:
-            return PairNode(subtree_fill_to_length(bottom, depth - 1, length), zero_node(depth))
+            return PairNode(subtree_fill_to_length(bottom, depth - 1, length), zero_node(depth-1))
         else:
             return PairNode(
                 subtree_fill_to_depth(bottom, depth-1),


### PR DESCRIPTION
When calling `subtree_fill_to_length` as part of a default constructor for a vector that has a non-power-of-2 length, the computation of the filler hash for unused nodes was incorrect.

e.g., the following would fail, and `hash_tree_root` would be incorrect.

```python
class Foo(Container):
    elems: Vector[Bytes32, 5]

assert Foo() == Foo(elems=[Bytes32()]*5)
```

Fixing the logic to use the correct `zero_node` for the empty subtree addresses this issue; implicit and explicit zeroing now behave same.