### PR TITLE
container equality with fields length check

### DIFF
--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -962,3 +962,8 @@ class Container(_ContainerBase):
 
     def navigate_view(self, key: Any) -> View:
         return self.__getattr__(key)
+
+    def __eq__(self, other):
+        if not isinstance(other, Container):
+            return False
+        return len(self.fields()) == len(other.fields()) and self.hash_tree_root() == other.hash_tree_root()


### PR DESCRIPTION
Users often rely on comparing different `View` types, so equality is only checking the `hash_tree_root` of a view. Containers are often extended with an additional field however, which may result in the new container having the same `hash_tree_root` when the new field has a 0 value. This change adds a length check to Containers to catch this case.
