### PR TITLE
fix container py hash

### DIFF
--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -967,3 +967,6 @@ class Container(_ContainerBase):
         if not isinstance(other, Container):
             return False
         return len(self.fields()) == len(other.fields()) and self.hash_tree_root() == other.hash_tree_root()
+
+    def __hash__(self):
+        return hash((self.hash_tree_root(), len(self.fields())))

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -456,3 +456,22 @@ def test_readonly_iters(name: str, typ: Type[View], value: View, serialized: str
         fields = list(value)
         expected = [getattr(value, fkey) for fkey in value.__class__.fields().keys()]
         assert fields == expected
+
+
+def test_container_equality():
+    class A(Container):
+        x: uint8
+        y: uint8
+        z: uint8
+
+    class B(Container):
+        x: uint8
+        y: uint8
+        z: uint8
+        v: uint8
+
+    assert A(1, 2, 3) == A(1, 2, 3)
+    assert B(1, 2, 3, 0) == B(1, 2, 3, 0)
+    assert A(1, 2, 3) != B(1, 2, 3, 0)
+    assert A(1, 2, 3) in {A(1, 2, 3)}
+    assert A(1, 2, 3) not in {B(1, 2, 3, 0)}


### PR DESCRIPTION
After adding `__eq__` the python class needed `__hash__` to match the equality conditions too