### PR TITLE
bugfix: computation of `__len__` generalized index

### DIFF
--- a/remerkleable/bitfields.py
+++ b/remerkleable/bitfields.py
@@ -326,6 +326,8 @@ class Bitlist(BitsView):
 
     @classmethod
     def navigate_type(cls, key: Any) -> Type[View]:
+        if key == '__len__':
+            return uint256
         bit_limit = cls.limit()
         if key < 0 or key >= bit_limit:
             raise KeyError

--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -461,6 +461,8 @@ class List(MonoSubtreeView):
 
     @classmethod
     def navigate_type(cls, key: Any) -> Type[View]:
+        if key == '__len__':
+            return uint256
         if key >= cls.limit():
             raise KeyError
         return super().navigate_type(key)

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -347,8 +347,17 @@ def test_paths():
     assert (Wrapper / 'b' / 'quix').navigate_view(w) == 42
 
     assert (List[uint32, 123] / 0).navigate_type() == uint32
+    assert (List[uint32, 123] / "__len__").navigate_type() == uint256
     try:
         (List[uint32, 123] / 123).navigate_type()
+        assert False
+    except KeyError:
+        pass
+
+    assert (Bitlist[123] / 0).navigate_type() == boolean
+    assert (Bitlist[123] / "__len__").navigate_type() == uint256
+    try:
+        (Bitlist[123] / 123).navigate_type()
         assert False
     except KeyError:
         pass


### PR DESCRIPTION
Fixes #20.

Refer to the issue for details on the problem, where `Path` computation for generalized indices relies on calling the SSZ type's `navigate_type` method.

The issue is that `navigate_type` assumes the incoming `key` is an integer value, when this assumption is violated with generalized indices which supports integer keys **or** a special `str` key `"__len__"` to refer to the types length in the Merkle backing.

Without a substantial refactor to the `Path` machinery and how it uses `navigate_type`, it seems we can just special-case this one exception to the base assumption. 

I also ran into the issue of *what* type to return as this method intends to only return a SSZ type. However, the list length (bounded by list limit) has no upper bound and so I just use Python's `int`. As there should be no further generalized index path after a path element of `"__len__"`, this should not cause any bugs, even if it muddies the semantics of the code somewhat.