### PR TITLE
Add support for `default_node` in `StableContainer` / `Profile`

### DIFF
--- a/.github/workflows/ci_py.yaml
+++ b/.github/workflows/ci_py.yaml
@@ -6,13 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Cache pip
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip # This path is specific to Ubuntu
           # Look to see if there is a cache hit for the corresponding requirements file

--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -108,6 +108,11 @@ class MonoSubtreeView(ColSequence, ComplexView):
             else:
                 return ComplexElemIter(backing, tree_depth, length, elem_type)
 
+    def check_backing(self):
+        for el in self:
+            if isinstance(el, BackedView):
+                el.check_backing()
+
     @classmethod
     def deserialize(cls: Type[M], stream: BinaryIO, scope: int) -> M:
         elem_cls = cls.element_cls()
@@ -284,9 +289,7 @@ class List(MonoSubtreeView):
                 raise Exception(f"too many list inputs: {len(vals)}, limit is: {limit}")
             input_views = []
             for el in vals:
-                if isinstance(el, BackedView):
-                    input_views.append(elem_cls(backing=el.get_backing()))
-                elif isinstance(el, View):
+                if isinstance(el, View):
                     input_views.append(el)
                 else:
                     input_views.append(elem_cls.coerce_view(el))
@@ -530,9 +533,7 @@ class Vector(MonoSubtreeView):
                 raise Exception(f"invalid inputs length: {len(vals)}, vector length is: {vector_length}")
             input_views = []
             for el in vals:
-                if isinstance(el, BackedView):
-                    input_views.append(elem_cls(backing=el.get_backing()))
-                elif isinstance(el, View):
+                if isinstance(el, View):
                     input_views.append(el)
                 else:
                     input_views.append(elem_cls.coerce_view(el))
@@ -719,6 +720,11 @@ class _ContainerBase(ComplexView):
     def fields(cls) -> Fields:  # base condition for the subclasses deriving the fields
         return {}
 
+    def check_backing(self):
+        for el in self:
+            if isinstance(el, BackedView):
+                el.check_backing()
+
 
 class Container(_ContainerBase):
     _field_indices: Dict[str, int]
@@ -736,9 +742,7 @@ class Container(_ContainerBase):
             fnode: Node
             if fkey in kwargs:
                 finput = kwargs.pop(fkey)
-                if isinstance(finput, BackedView):
-                    fnode = ftyp(backing=finput.get_backing()).get_backing()
-                elif isinstance(finput, View):
+                if isinstance(finput, View):
                     fnode = finput.get_backing()
                 else:
                     fnode = ftyp.coerce_view(finput).get_backing()

--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -5,7 +5,8 @@ from textwrap import indent
 from collections.abc import Sequence as ColSequence
 from itertools import chain
 import io
-from remerkleable.core import View, BasicView, OFFSET_BYTE_LENGTH, ViewHook, ObjType, ObjParseException
+from remerkleable.core import View, BackedView, BasicView, OFFSET_BYTE_LENGTH,\
+    ViewHook, ObjType, ObjParseException
 from remerkleable.basic import uint256, uint8, uint32
 from remerkleable.tree import Node, subtree_fill_to_length, subtree_fill_to_contents,\
     zero_node, Gindex, PairNode, to_gindex, NavigationError, get_depth, RIGHT_GINDEX
@@ -283,7 +284,9 @@ class List(MonoSubtreeView):
                 raise Exception(f"too many list inputs: {len(vals)}, limit is: {limit}")
             input_views = []
             for el in vals:
-                if isinstance(el, View):
+                if isinstance(el, BackedView):
+                    input_views.append(elem_cls(backing=el.get_backing()))
+                elif isinstance(el, View):
                     input_views.append(el)
                 else:
                     input_views.append(elem_cls.coerce_view(el))
@@ -527,7 +530,9 @@ class Vector(MonoSubtreeView):
                 raise Exception(f"invalid inputs length: {len(vals)}, vector length is: {vector_length}")
             input_views = []
             for el in vals:
-                if isinstance(el, View):
+                if isinstance(el, BackedView):
+                    input_views.append(elem_cls(backing=el.get_backing()))
+                elif isinstance(el, View):
                     input_views.append(el)
                 else:
                     input_views.append(elem_cls.coerce_view(el))
@@ -731,7 +736,9 @@ class Container(_ContainerBase):
             fnode: Node
             if fkey in kwargs:
                 finput = kwargs.pop(fkey)
-                if isinstance(finput, View):
+                if isinstance(finput, BackedView):
+                    fnode = ftyp(backing=finput.get_backing()).get_backing()
+                elif isinstance(finput, View):
                     fnode = finput.get_backing()
                 else:
                     fnode = ftyp.coerce_view(finput).get_backing()

--- a/remerkleable/core.py
+++ b/remerkleable/core.py
@@ -238,6 +238,9 @@ class BackedView(View):
         out._hook = hook
         return out
 
+    def __init__(self, *args, **kwargs):
+        self.check_backing()
+
     def get_backing(self) -> Node:
         return self._backing
 
@@ -246,6 +249,9 @@ class BackedView(View):
         # Propagate up the change if the view is hooked to a super view
         if self._hook is not None:
             self._hook(self)
+
+    def check_backing(self):
+        pass
 
 
 BV = TypeVar('BV', bound="BasicView")

--- a/remerkleable/core.py
+++ b/remerkleable/core.py
@@ -238,9 +238,6 @@ class BackedView(View):
         out._hook = hook
         return out
 
-    def __init__(self, *args, **kwargs):
-        self.check_backing()
-
     def get_backing(self) -> Node:
         return self._backing
 
@@ -252,6 +249,15 @@ class BackedView(View):
 
     def check_backing(self):
         pass
+
+    @classmethod
+    def from_base(cls: Type[BackedV], value) -> BackedV:
+        res = cls(backing=value.get_backing())
+        res.check_backing()
+        return res
+
+    def to_base(self, cls: Type[BackedV]) -> BackedV:
+        return cls(backing=self.get_backing())
 
 
 BV = TypeVar('BV', bound="BasicView")

--- a/remerkleable/stable_container.py
+++ b/remerkleable/stable_container.py
@@ -141,6 +141,10 @@ class StableContainer(ComplexView):
         return StableContainerView
 
     @classmethod
+    def coerce_view(cls: Type[SV], v: Any) -> SV:
+        return cls(**{fkey: getattr(v, fkey) for fkey in cls.fields().keys()})
+
+    @classmethod
     def fields(cls) -> Dict[str, Type[View]]:
         return { fkey: ftyp for fkey, (_, ftyp) in cls._field_indices.items() }
 
@@ -502,6 +506,10 @@ class Profile(ComplexView):
 
         ProfileView.__name__ = ProfileView.type_repr()
         return ProfileView
+
+    @classmethod
+    def coerce_view(cls: Type[BV], v: Any) -> BV:
+        return cls(**{fkey: getattr(v, fkey) for fkey in cls.fields().keys()})
 
     @classmethod
     def fields(cls) -> Dict[str, Tuple[Type[View], bool]]:

--- a/remerkleable/stable_container.py
+++ b/remerkleable/stable_container.py
@@ -107,7 +107,7 @@ class StableContainer(ComplexView):
             raise TypeError(f'Invalid capacity: `StableContainer[{n}]`')
         if n <= 0:
             raise TypeError(f'Unsupported capacity: `StableContainer[{n}]`')
-        cls.N = n
+        cls.N = int(n)
 
     def __class_getitem__(cls, n: int) -> Type['StableContainer']:
         class StableContainerMeta(ViewMeta):

--- a/remerkleable/stable_container.py
+++ b/remerkleable/stable_container.py
@@ -26,7 +26,7 @@ def stable_get(self, findex, ftyp, n):
         return None
     data = self.get_backing().get_left()
     fnode = data.getter(2**get_depth(n) + findex)
-    return ftyp.view_from_backing(fnode)
+    return ftyp.view_from_backing(fnode, lambda v: stable_set(self, findex, ftyp, n, v))
 
 
 def stable_set(self, findex, ftyp, n, value):

--- a/remerkleable/stable_container.py
+++ b/remerkleable/stable_container.py
@@ -266,6 +266,9 @@ class StableContainer(ComplexView):
                                     f'{foffset}, next {next_offset}, implied size: {fsize}, '
                                     f'size bounds: [{f_min_size}, {f_max_size}]')
                 field_values[fkey] = ftyp.deserialize(stream, fsize)
+        else:
+            if scope != fixed_size:
+                raise Exception(f'Incorrect object size: {scope}, expected: {fixed_size}')
         return cls(**field_values)  # type: ignore
 
     def serialize(self, stream: BinaryIO) -> int:
@@ -677,6 +680,9 @@ class Profile(ComplexView):
                                     f'{foffset}, next {next_offset}, implied size: {fsize}, '
                                     f'size bounds: [{f_min_size}, {f_max_size}]')
                 field_values[fkey] = ftyp.deserialize(stream, fsize)
+        else:
+            if scope != fixed_size:
+                raise Exception(f'Incorrect object size: {scope}, expected: {fixed_size}')
         return cls(**field_values)  # type: ignore
 
     def serialize(self, stream: BinaryIO) -> int:

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -541,23 +541,14 @@ def test_stable_container():
     )
     assert all(shape.hash_tree_root() == square_root for shape in shapes)
     assert all(square.hash_tree_root() == square_root for square in squares)
-    try:
+    with pytest.raises(Exception):
         circle = Circle(side=0x42, color=1)
-        assert False
-    except:
-        pass
     for shape in shapes:
-        try:
+        with pytest.raises(Exception):
             circle = Circle(backing=shape.get_backing())
-            assert False
-        except:
-            pass
     for square in squares:
-        try:
+        with pytest.raises(Exception):
             circle = Circle(backing=square.get_backing())
-            assert False
-        except:
-            pass
     for shape in shapes:
         shape.side = 0x1337
     for square in squares:
@@ -579,17 +570,11 @@ def test_stable_container():
     assert all(shape.hash_tree_root() == square_root for shape in shapes)
     assert all(square.hash_tree_root() == square_root for square in squares)
     for square in squares:
-        try:
+        with pytest.raises(Exception):
             square.radius = 0x1337
-            assert False
-        except:
-            pass
     for square in squares:
-        try:
+        with pytest.raises(Exception):
             square.side = None
-            assert False
-        except:
-            pass
 
     # Circle tests
     circle_bytes_stable = bytes.fromhex("06014200")
@@ -617,23 +602,14 @@ def test_stable_container():
     )
     assert all(shape.hash_tree_root() == circle_root for shape in shapes)
     assert all(circle.hash_tree_root() == circle_root for circle in circles)
-    try:
+    with pytest.raises(Exception):
         square = Square(radius=0x42, color=1)
-        assert False
-    except:
-        pass
     for shape in shapes:
-        try:
+        with pytest.raises(Exception):
             square = Square(backing=shape.get_backing())
-            assert False
-        except:
-            pass
     for circle in circles:
-        try:
+        with pytest.raises(Exception):
             square = Square(backing=circle.get_backing())
-            assert False
-        except:
-            pass
 
     # SquarePair tests
     square_pair_bytes_stable = bytes.fromhex("080000000c0000000342000103690001")
@@ -712,45 +688,24 @@ def test_stable_container():
     shape_bytes = bytes.fromhex("0201")
     assert shape.encode_bytes() == shape_bytes
     assert Shape.decode_bytes(shape_bytes) == shape
-    try:
+    with pytest.raises(Exception):
         shape = Square.decode_bytes(shape_bytes)
-        assert False
-    except:
-        pass
-    try:
+    with pytest.raises(Exception):
         shape = Circle.decode_bytes(shape_bytes)
-        assert False
-    except:
-        pass
     shape = Shape(side=0x42, color=1, radius=0x42)
     shape_bytes = bytes.fromhex("074200014200")
     assert shape.encode_bytes() == shape_bytes
     assert Shape.decode_bytes(shape_bytes) == shape
-    try:
+    with pytest.raises(Exception):
         shape = Square.decode_bytes(shape_bytes)
-        assert False
-    except:
-        pass
-    try:
+    with pytest.raises(Exception):
         shape = Circle.decode_bytes(shape_bytes)
-        assert False
-    except:
-        pass
-    try:
+    with pytest.raises(Exception):
         shape = Shape.decode_bytes("00")
-        assert False
-    except:
-        pass
-    try:
+    with pytest.raises(Exception):
         square = Square(radius=0x42, color=1)
-        assert False
-    except:
-        pass
-    try:
+    with pytest.raises(Exception):
         circle = Circle(side=0x42, color=1)
-        assert False
-    except:
-        pass
 
     # Surrounding container tests
     class ShapeContainer(Container):

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -802,7 +802,7 @@ def test_stable_container():
     shape = NestedCircleContainer(item=CircleContainer(shape=Circle(radius=0x42, color=1)))
     assert NestedCircleContainer.from_base(shape.to_base(NestedShapeContainer)) == shape
     with pytest.raises(Exception):
-        shape = NestedSquareContainer.from_base(shape.to_base(NestedShapeContainer)) == shape
+        shape = NestedSquareContainer.from_base(shape.to_base(NestedShapeContainer))
 
     # basic container
     class Shape1(StableContainer[4]):

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -707,8 +707,6 @@ def test_stable_container():
     with pytest.raises(Exception):
         circle = Circle(side=0x42, color=1)
     with pytest.raises(Exception):
-        square = Square.coerce_view(Shape(radius=0x42, color=1))
-    with pytest.raises(Exception):
         square = Square(backing=Circle(radius=0x42, color=1).get_backing())
 
     # Surrounding container tests
@@ -747,11 +745,11 @@ def test_stable_container():
 
     # Unsupported surrounding container tests
     with pytest.raises(Exception):
-        shapes = List[Square, 5].coerce_view(
-            List[Circle, 5](Circle(radius=0x42, color=1)))
+        shapes = List[Square, 5](
+            backing=List[Circle, 5](Circle(radius=0x42, color=1)).get_backing())
     with pytest.raises(Exception):
-        shapes = Vector[Square, 1].coerce_view(
-            Vector[Circle, 1](Circle(radius=0x42, color=1)))
+        shapes = Vector[Square, 1](
+            backing=Vector[Circle, 1](Circle(radius=0x42, color=1)).get_backing())
 
     class SquareContainer(Container):
         shape: Square
@@ -760,8 +758,8 @@ def test_stable_container():
         shape: Circle
 
     with pytest.raises(Exception):
-        shape = SquareContainer.coerce_view(
-            CircleContainer(shape=Circle(radius=0x42, color=1)))
+        shape = SquareContainer(
+            backing=CircleContainer(shape=Circle(radius=0x42, color=1)).get_backing())
 
     class SquareStableContainer(StableContainer[1]):
         shape: Optional[Square]
@@ -770,8 +768,19 @@ def test_stable_container():
         shape: Optional[Circle]
 
     with pytest.raises(Exception):
-        shape = SquareStableContainer.coerce_view(
-            CircleStableContainer(shape=Circle(radius=0x42, color=1)))
+        shape = SquareStableContainer(
+            backing=CircleStableContainer(shape=Circle(radius=0x42, color=1)).get_backing())
+
+    class NestedSquareContainer(Container):
+        item: SquareContainer
+
+    class NestedCircleContainer(Container):
+        item: CircleContainer
+
+    with pytest.raises(Exception):
+        shape = NestedSquareContainer(
+            backing=NestedCircleContainer(
+                item=CircleContainer(shape=Circle(radius=0x42, color=1))).get_backing())
 
     # basic container
     class Shape1(StableContainer[4]):

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -527,16 +527,18 @@ def test_stable_container():
     ).hash_tree_root()
     shapes = [Shape(side=0x42, color=1, radius=None)]
     squares = [Square(side=0x42, color=1)]
-    squares.extend(list(Square(backing=shape.get_backing()) for shape in shapes))
-    shapes.extend(list(Shape(backing=shape.get_backing()) for shape in shapes))
-    shapes.extend(list(Shape(backing=square.get_backing()) for square in squares))
-    squares.extend(list(Square(backing=square.get_backing()) for square in squares))
+    squares.extend(list(Square.from_base(shape) for shape in shapes))
+    shapes.extend(list(Shape(
+        side=shape.side, radius=shape.radius, color=shape.color
+    ) for shape in shapes))
+    shapes.extend(list(square.to_base(Shape) for square in squares))
+    squares.extend(list(Square(side=square.side, color=square.color) for square in squares))
     assert len(set(shapes)) == 1
     assert len(set(squares)) == 1
     assert all(shape.encode_bytes() == square_bytes_stable for shape in shapes)
     assert all(square.encode_bytes() == square_bytes_profile for square in squares)
     assert (
-        Square(backing=Shape.decode_bytes(square_bytes_stable).get_backing()) ==
+        Square.from_base(Shape.decode_bytes(square_bytes_stable)) ==
         Square.decode_bytes(square_bytes_profile)
     )
     assert all(shape.hash_tree_root() == square_root for shape in shapes)
@@ -545,10 +547,10 @@ def test_stable_container():
         circle = Circle(side=0x42, color=1)
     for shape in shapes:
         with pytest.raises(Exception):
-            circle = Circle(backing=shape.get_backing())
+            circle = Circle.from_base(shape)
     for square in squares:
         with pytest.raises(Exception):
-            circle = Circle(backing=square.get_backing())
+            circle = Circle.from_base(square.to_base(Shape))
     for shape in shapes:
         shape.side = 0x1337
     for square in squares:
@@ -564,7 +566,7 @@ def test_stable_container():
     assert all(shape.encode_bytes() == square_bytes_stable for shape in shapes)
     assert all(square.encode_bytes() == square_bytes_profile for square in squares)
     assert (
-        Square(backing=Shape.decode_bytes(square_bytes_stable).get_backing()) ==
+        Square.from_base(Shape.decode_bytes(square_bytes_stable)) ==
         Square.decode_bytes(square_bytes_profile)
     )
     assert all(shape.hash_tree_root() == square_root for shape in shapes)
@@ -588,16 +590,18 @@ def test_stable_container():
     modified_shape.radius = 0x42
     shapes = [Shape(side=None, color=1, radius=0x42), modified_shape]
     circles = [Circle(radius=0x42, color=1)]
-    circles.extend(list(Circle(backing=shape.get_backing()) for shape in shapes))
-    shapes.extend(list(Shape(backing=shape.get_backing()) for shape in shapes))
-    shapes.extend(list(Shape(backing=circle.get_backing()) for circle in circles))
-    circles.extend(list(Circle(backing=circle.get_backing()) for circle in circles))
+    circles.extend(list(Circle.from_base(shape) for shape in shapes))
+    shapes.extend(list(Shape(
+        side=shape.side, radius=shape.radius, color=shape.color
+    ) for shape in shapes))
+    shapes.extend(list(circle.to_base(Shape) for circle in circles))
+    circles.extend(list(Circle(radius=circle.radius, color=circle.color) for circle in circles))
     assert len(set(shapes)) == 1
     assert len(set(circles)) == 1
     assert all(shape.encode_bytes() == circle_bytes_stable for shape in shapes)
     assert all(circle.encode_bytes() == circle_bytes_profile for circle in circles)
     assert (
-        Circle(backing=Shape.decode_bytes(circle_bytes_stable).get_backing()) ==
+        Circle.from_base(Shape.decode_bytes(circle_bytes_stable)) ==
         Circle.decode_bytes(circle_bytes_profile)
     )
     assert all(shape.hash_tree_root() == circle_root for shape in shapes)
@@ -606,10 +610,10 @@ def test_stable_container():
         square = Square(radius=0x42, color=1)
     for shape in shapes:
         with pytest.raises(Exception):
-            square = Square(backing=shape.get_backing())
+            square = Square.from_base(shape)
     for circle in circles:
         with pytest.raises(Exception):
-            square = Square(backing=circle.get_backing())
+            square = Square.from_base(circle.to_base(Shape))
 
     # SquarePair tests
     square_pair_bytes_stable = bytes.fromhex("080000000c0000000342000103690001")
@@ -632,16 +636,18 @@ def test_stable_container():
         shape_1=Square(side=0x42, color=1),
         shape_2=Square(side=0x69, color=1),
     )]
-    square_pairs.extend(list(SquarePair(backing=pair.get_backing()) for pair in shape_pairs))
-    shape_pairs.extend(list(ShapePair(backing=pair.get_backing()) for pair in shape_pairs))
-    shape_pairs.extend(list(ShapePair(backing=pair.get_backing()) for pair in square_pairs))
-    square_pairs.extend(list(SquarePair(backing=pair.get_backing()) for pair in square_pairs))
+    square_pairs.extend(list(SquarePair.from_base(pair) for pair in shape_pairs))
+    shape_pairs.extend(list(ShapePair(
+        shape_1=pair.shape_1, shape_2=pair.shape_2) for pair in shape_pairs))
+    shape_pairs.extend(list(pair.to_base(ShapePair) for pair in square_pairs))
+    square_pairs.extend(list(SquarePair(
+        shape_1=pair.shape_1, shape_2=pair.shape_2) for pair in square_pairs))
     assert len(set(shape_pairs)) == 1
     assert len(set(square_pairs)) == 1
     assert all(pair.encode_bytes() == square_pair_bytes_stable for pair in shape_pairs)
     assert all(pair.encode_bytes() == square_pair_bytes_profile for pair in square_pairs)
     assert (
-        SquarePair(backing=ShapePair.decode_bytes(square_pair_bytes_stable).get_backing()) ==
+        SquarePair.from_base(ShapePair.decode_bytes(square_pair_bytes_stable)) ==
         SquarePair.decode_bytes(square_pair_bytes_profile)
     )
     assert all(pair.hash_tree_root() == square_pair_root for pair in shape_pairs)
@@ -668,16 +674,18 @@ def test_stable_container():
         shape_1=Circle(radius=0x42, color=1),
         shape_2=Circle(radius=0x69, color=1),
     )]
-    circle_pairs.extend(list(CirclePair(backing=pair.get_backing()) for pair in shape_pairs))
-    shape_pairs.extend(list(ShapePair(backing=pair.get_backing()) for pair in shape_pairs))
-    shape_pairs.extend(list(ShapePair(backing=pair.get_backing()) for pair in circle_pairs))
-    circle_pairs.extend(list(CirclePair(backing=pair.get_backing()) for pair in circle_pairs))
+    circle_pairs.extend(list(CirclePair.from_base(pair) for pair in shape_pairs))
+    shape_pairs.extend(list(ShapePair(
+        shape_1=pair.shape_1, shape_2=pair.shape_2) for pair in shape_pairs))
+    shape_pairs.extend(list(pair.to_base(ShapePair) for pair in circle_pairs))
+    circle_pairs.extend(list(CirclePair(
+        shape_1=pair.shape_1, shape_2=pair.shape_2) for pair in circle_pairs))
     assert len(set(shape_pairs)) == 1
     assert len(set(circle_pairs)) == 1
     assert all(pair.encode_bytes() == circle_pair_bytes_stable for pair in shape_pairs)
     assert all(pair.encode_bytes() == circle_pair_bytes_profile for pair in circle_pairs)
     assert (
-        CirclePair(backing=ShapePair.decode_bytes(circle_pair_bytes_stable).get_backing()) ==
+        CirclePair.from_base(ShapePair.decode_bytes(circle_pair_bytes_stable)) ==
         CirclePair.decode_bytes(circle_pair_bytes_profile)
     )
     assert all(pair.hash_tree_root() == circle_pair_root for pair in shape_pairs)
@@ -707,7 +715,7 @@ def test_stable_container():
     with pytest.raises(Exception):
         circle = Circle(side=0x42, color=1)
     with pytest.raises(Exception):
-        square = Square(backing=Circle(radius=0x42, color=1).get_backing())
+        square = Square.from_base(Circle(radius=0x42, color=1).to_base(Shape))
 
     # Surrounding container tests
     class ShapeContainer(Container):
@@ -743,13 +751,19 @@ def test_stable_container():
         ),
     ).hash_tree_root()
 
-    # Unsupported surrounding container tests
+    # Nested surrounding container tests
+    shapes = List[Circle, 5](Circle(radius=0x42, color=1))
+    assert List[Circle, 5].from_base(shapes.to_base(List[Shape, 5])) == shapes
     with pytest.raises(Exception):
-        shapes = List[Square, 5](
-            backing=List[Circle, 5](Circle(radius=0x42, color=1)).get_backing())
+        shapes = List[Square, 5].from_base(shapes.to_base(List[Shape, 5]))
+
+    shapes = Vector[Circle, 1](Circle(radius=0x42, color=1))
+    assert Vector[Circle, 1].from_base(shapes.to_base(Vector[Shape, 1])) == shapes
     with pytest.raises(Exception):
-        shapes = Vector[Square, 1](
-            backing=Vector[Circle, 1](Circle(radius=0x42, color=1)).get_backing())
+        shapes = Vector[Square, 1].from_base(shapes.to_base(Vector[Shape, 1]))
+
+    class ShapeContainer(Container):
+        shape: Shape
 
     class SquareContainer(Container):
         shape: Square
@@ -757,9 +771,13 @@ def test_stable_container():
     class CircleContainer(Container):
         shape: Circle
 
+    shape = CircleContainer(shape=Circle(radius=0x42, color=1))
+    assert CircleContainer.from_base(shape.to_base(ShapeContainer)) == shape
     with pytest.raises(Exception):
-        shape = SquareContainer(
-            backing=CircleContainer(shape=Circle(radius=0x42, color=1)).get_backing())
+        shape = SquareContainer.from_base(shape.to_base(ShapeContainer))
+
+    class ShapeStableContainer(StableContainer[1]):
+        shape: Optional[Shape]
 
     class SquareStableContainer(StableContainer[1]):
         shape: Optional[Square]
@@ -767,9 +785,13 @@ def test_stable_container():
     class CircleStableContainer(StableContainer[1]):
         shape: Optional[Circle]
 
+    shape = CircleStableContainer(shape=Circle(radius=0x42, color=1))
+    assert CircleStableContainer.from_base(shape.to_base(ShapeStableContainer)) == shape
     with pytest.raises(Exception):
-        shape = SquareStableContainer(
-            backing=CircleStableContainer(shape=Circle(radius=0x42, color=1)).get_backing())
+        shape = SquareStableContainer.from_base(shape.to_base(ShapeStableContainer))
+
+    class NestedShapeContainer(Container):
+        item: ShapeContainer
 
     class NestedSquareContainer(Container):
         item: SquareContainer
@@ -777,10 +799,10 @@ def test_stable_container():
     class NestedCircleContainer(Container):
         item: CircleContainer
 
+    shape = NestedCircleContainer(item=CircleContainer(shape=Circle(radius=0x42, color=1)))
+    assert NestedCircleContainer.from_base(shape.to_base(NestedShapeContainer)) == shape
     with pytest.raises(Exception):
-        shape = NestedSquareContainer(
-            backing=NestedCircleContainer(
-                item=CircleContainer(shape=Circle(radius=0x42, color=1))).get_backing())
+        shape = NestedSquareContainer.from_base(shape.to_base(NestedShapeContainer)) == shape
 
     # basic container
     class Shape1(StableContainer[4]):

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -706,6 +706,10 @@ def test_stable_container():
         square = Square(radius=0x42, color=1)
     with pytest.raises(Exception):
         circle = Circle(side=0x42, color=1)
+    with pytest.raises(Exception):
+        square = Square.coerce_view(Shape(radius=0x42, color=1))
+    with pytest.raises(Exception):
+        square = Square(backing=Circle(radius=0x42, color=1).get_backing())
 
     # Surrounding container tests
     class ShapeContainer(Container):
@@ -740,6 +744,34 @@ def test_stable_container():
             active_fields=Bitvector[4](False, True, True, False),
         ),
     ).hash_tree_root()
+
+    # Unsupported surrounding container tests
+    with pytest.raises(Exception):
+        shapes = List[Square, 5].coerce_view(
+            List[Circle, 5](Circle(radius=0x42, color=1)))
+    with pytest.raises(Exception):
+        shapes = Vector[Square, 1].coerce_view(
+            Vector[Circle, 1](Circle(radius=0x42, color=1)))
+
+    class SquareContainer(Container):
+        shape: Square
+
+    class CircleContainer(Container):
+        shape: Circle
+
+    with pytest.raises(Exception):
+        shape = SquareContainer.coerce_view(
+            CircleContainer(shape=Circle(radius=0x42, color=1)))
+
+    class SquareStableContainer(StableContainer[1]):
+        shape: Optional[Square]
+
+    class CircleStableContainer(StableContainer[1]):
+        shape: Optional[Circle]
+
+    with pytest.raises(Exception):
+        shape = SquareStableContainer.coerce_view(
+            CircleStableContainer(shape=Circle(radius=0x42, color=1)))
 
     # basic container
     class Shape1(StableContainer[4]):


### PR DESCRIPTION
Implement `default_node` so that incomplete initialization becomes possible, similar to how it works for `Container` when not all fields are explicitly defined during construction.